### PR TITLE
Rename firmware to reduce errors

### DIFF
--- a/README.ACTION.md
+++ b/README.ACTION.md
@@ -41,7 +41,7 @@
 
 | 参数                   | 默认值                  | 说明                                            |
 |------------------------|------------------------|------------------------------------------------|
-| OPENWRT_ARMVIRT_PATH   | no                     | 必选项. 设置 `openwrt-armvirt-64-default-rootfs.tar.gz` 的文件路径，可以使用相对路径如 `openwrt/bin/targets/*/*/*.tar.gz` 或 网络文件下载地址如 `https://github.com/*/releases/*/openwrt-armvirt-64-default-rootfs.tar.gz` |
+| OPENWRT_ARMVIRT   | no                     | 必选项. 设置 `openwrt-armvirt-64-default-rootfs.tar.gz` 的文件路径，可以使用相对路径如 `openwrt/bin/targets/*/*/*.tar.gz` 或 网络文件下载地址如 `https://github.com/*/releases/*/openwrt-armvirt-64-default-rootfs.tar.gz` |
 | KERNEL_REPO_URL        | [breakings/.../kernel](openwrt_flippy.sh#L23) | 设置内核下载地址，默认从 breakings 维护的 [kernel](https://github.com/breakings/OpenWrt/tree/main/opt/kernel) 库里下载 Flippy 的内核。 |
 | KERNEL_VERSION_NAME    | 5.14.12_5.4.153        | 设置内核版本，[kernel](https://github.com/breakings/OpenWrt/tree/main/opt/kernel) 库里收藏了众多 Flippy 的原版内核，可以查看并选择指定。可指定单个内核如 `5.4.147` ，可选择多个内核用`_`连接如 `5.10.66_5.4.147` ，内核名称以 kernel 目录中的文件夹名称为准。 |
 | KERNEL_AUTO_LATEST     | true                   | 设置是否自动采用同系列最新版本内核。当为 `true` 时，将自动在内核库中查找在 `KERNEL_VERSION_NAME` 中指定的内核如 5.4.147 的 5.4 同系列是否有更新的版本，如有更新版本时，将自动更换为最新版。设置为 `false` 时将编译指定版本内核。 |

--- a/openwrt_flippy.sh
+++ b/openwrt_flippy.sh
@@ -122,10 +122,10 @@ sync
 # Load openwrt-armvirt-64-default-rootfs.tar.gz
 if [[ ${OPENWRT_ARMVIRT} == http* ]]; then
     echo -e "${STEPS} wget [ ${OPENWRT_ARMVIRT} ] file into ${SELECT_PACKITPATH}"
-    wget ${OPENWRT_ARMVIRT} -q -P ${SELECT_PACKITPATH}
+    wget -O openwrt-armvirt-64-default-rootfs.tar.gz ${OPENWRT_ARMVIRT} -q -P ${SELECT_PACKITPATH}
 else
     echo -e "${STEPS} copy [ ${GITHUB_WORKSPACE}/${OPENWRT_ARMVIRT} ] file into ${SELECT_PACKITPATH}"
-    cp -f ${GITHUB_WORKSPACE}/${OPENWRT_ARMVIRT} ${SELECT_PACKITPATH}
+    cp -f ${GITHUB_WORKSPACE}/${OPENWRT_ARMVIRT} ${SELECT_PACKITPATH}/openwrt-armvirt-64-default-rootfs.tar.gz
 fi
 sync
 


### PR DESCRIPTION
用其他源码编译生成的固件名不一定为openwrt-armvirt-64-default-rootfs.tar.gz
如immortalwrt的源码生成后为immortalwrt-armvirt-64-default-rootfs.tar.gz
避免打包失败，输入/opt时重命名该文件为openwrt-armvirt-64-default-rootfs.tar.gz