### PR TITLE
修复 r68s eth2 和 eth3 启动的时候不工作的问题

### DIFF
--- a/files/rk3568/50-pcie_eth_up
+++ b/files/rk3568/50-pcie_eth_up
@@ -1,0 +1,12 @@
+# Bring eth2 and eth3 up when boot
+
+. /lib/functions/uci-defaults.sh
+
+board_config_update
+
+ip link set dev eth2 up
+ip link set dev eth3 up
+
+board_config_flush
+
+exit 0

--- a/mk_rk3568_r68s.sh
+++ b/mk_rk3568_r68s.sh
@@ -107,6 +107,8 @@ DDBR="${PWD}/files/openwrt-ddbr"
 # 20220225 add
 SSH_CIPHERS="aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr,chacha20-poly1305@openssh.com"
 SSHD_CIPHERS="aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr"
+# 20220804 add
+BOARD_SCRIPT1="${PWD}/files/rk3568/50-pcie_eth_up"
 ####################################################################
 
 check_depends
@@ -136,7 +138,7 @@ overlay_prefix=rockchip
 rootdev=UUID=${ROOTFS_UUID}
 rootfstype=btrfs
 rootflags=compress=zstd:${ZSTD_LEVEL}
-extraargs=usbcore.autosuspend=-1
+extraargs=usbcore.autosuspend=-1 net.ifnames=0
 extraboardargs=
 fdtfile=/dtb/rockchip/rk3568-fastrhino-r68s.dtb
 console=serial

--- a/public_funcs
+++ b/public_funcs
@@ -1083,6 +1083,8 @@ function copy_supplement_files() {
         [ -n "$GETCPU_SCRIPT" ] && [ -f $GETCPU_SCRIPT ] && cp -v $GETCPU_SCRIPT ./bin/
         [ -n "$SYSINFO_SCRIPT" ] && [ -x ./bin/bash ] && [ -f "${SYSINFO_SCRIPT}" ] && cp -v "${SYSINFO_SCRIPT}" ./etc/profile.d/ && \
              sed -e "s/\/bin\/ash/\/bin\/bash/" -i ./etc/passwd && sed -e "s/\/bin\/ash/\/bin\/bash/" -i ./usr/libexec/login.sh
+        
+        [ -n "$BOARD_SCRIPT1" ] && [ -f $BOARD_SCRIPT1 ] && cp -v $BOARD_SCRIPT1 ./etc/board.d/
 
         [ -f ./etc/sysupgrade.conf ] && \
              cat >> ./etc/sysupgrade.conf <<EOF


### PR DESCRIPTION
之前可能是测麻了，重复测试的时候发现重启也不行，俩 PCIE 网卡开机就是不工作，用 r8125 和 r8169 都是

还没找到原因，只能先每次开机 set link up 修复一下了

启动参数增加了 `net.ifnames=0` 防止两个网卡被自动重命名