### PR TITLE
更新 r68s 初始化网络配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
        *** 必选软件包(基础依赖包，仅保证打出的包可以写入EMMC,可以在EMMC上在线升级，不包含具体的应用)： 
        Languages -> Perl               
                     ->  perl-http-date
-                    ->  perbase-file
+                    ->  perlbase-file
                     ->  perlbase-getopt
                     ->  perlbase-time
                     ->  perlbase-unicode                              

--- a/files/rk3568/50-pcie_eth_up
+++ b/files/rk3568/50-pcie_eth_up
@@ -1,11 +1,42 @@
-# Bring eth2 and eth3 up when boot
+# The default order of phy interfaces for r68s is
+# eth1(1G) eth0(1G) eth3(2.5G) eth2(2.5G)
+# Reset to 0 1 2 3 for intuitive
 
 . /lib/functions/uci-defaults.sh
+. /lib/functions/system.sh
 
 board_config_update
 
-ip link set dev eth2 up
-ip link set dev eth3 up
+nanopi_r2s_generate_mac()
+{
+	local sd_hash=$(sha256sum /sys/class/block/mmcblk0/device/cid)
+	local mac_base=$(macaddr_canonicalize "$(echo "${sd_hash}" | dd bs=1 count=12 2>/dev/null)")
+	echo "$(macaddr_unsetbit_mc "$(macaddr_setbit_la "${mac_base}")")"
+}
+
+swap_interface()
+{
+	local eth_a=$1
+	local eth_b=$2
+	ip link set dev $eth_a down
+	ip link set dev $eth_b down
+	ip link set $eth_a name eth-rename-tmp
+	ip link set $eth_b name $eth_a
+	ip link set eth-rename-tmp name $eth_b
+	ip link set dev $eth_a up
+	ip link set dev $eth_b up
+}
+
+# Swap eth0 & eth1, eth2 & eth3
+[ -d /sys/devices/platform/fe010000.ethernet/net/eth0 ] && swap_interface "eth2" "eth3"
+[ -d /sys/devices/platform/fe010000.ethernet/net/eth0 ] && swap_interface "eth0" "eth1"
+
+# Init LAN and WAN
+json_is_a network object && exit 0
+WAN_MAC=$(nanopi_r2s_generate_mac)
+ucidef_set_interfaces_lan_wan 'eth1 eth2 eth3' 'eth0'
+ucidef_set_interface_macaddr "wan" $WAN_MAC
+ucidef_set_interface_macaddr "lan" $(macaddr_add $WAN_MAC +1)
 
 board_config_flush
 


### PR DESCRIPTION
r68s 现在从左到右的网卡顺序是 `eth1 eth0 eth3 eth2`，不知道顺序的人应该很难找准口子

做了如下修改
1. 交换 eth0 与 eth1，eth2 与 eth3 的名字
2. 刷机之后默认将两个 2.5G 网口也加入 LAN
3. 使用 `mmcblk0 cid` 生成 WAN 和 LAN 的 MAC 地址

更新之后 r68s 初次刷机之后的网口为
| WAN  | LAN  | LAN  | LAN  |
| ---- | ---- | ---- | ---- |
| eth0 | eth1 | eth2 | eth3 |
| 1G   | 1G   | 2.5G | 2.5G |