### PR TITLE
Add support for custom firmware upgrade

### DIFF
--- a/files/openwrt-update-allwinner
+++ b/files/openwrt-update-allwinner
@@ -19,15 +19,22 @@ AUTO_MAINLINE_UBOOT=${2}
 BACKUP_RESTORE_CONFIG=${3}
 
 # Current FDT file
-if [ -f /boot/uEnv.txt ]; then
+if [[ -f "/boot/uEnv.txt" ]]; then
     source /boot/uEnv.txt 2>/dev/null
-    CURRENT_FDTFILE=$(basename $FDT)
+    MYDTB_FDTFILE=$(basename $FDT)
+elif [[ -f "/boot/armbianEnv.txt" ]]; then
+    source /boot/armbianEnv.txt 2>/dev/null
+    MYDTB_FDTFILE="$(basename $fdtfile)"
+elif [[ -f "/etc/flippy-openwrt-release" ]]; then
+    source /etc/flippy-openwrt-release 2>/dev/null
+    MYDTB_FDTFILE="${FDTFILE}"
 fi
-if [ -n "$CURRENT_FDTFILE" ]; then
-    MYDTB_FDTFILE="$CURRENT_FDTFILE"
-else
-    MYDTB_FDTFILE="sun50i-h6-vplus-cloud.dtb"
-fi
+
+[[ -z "${MYDTB_FDTFILE}" ]] && {
+    echo "Invalid FDTFILE: [ ${MYDTB_FDTFILE} ]"
+    exit 1
+}
+
 # Current device model
 MYDEVICE_NAME=$(cat /proc/device-tree/model | tr -d '\000')
 if [[ -z "${MYDEVICE_NAME}" ]]; then

--- a/files/openwrt-update-rockchip
+++ b/files/openwrt-update-rockchip
@@ -125,10 +125,24 @@ elif [[ "$(echo ${MYDEVICE_NAME} | grep "HINLINK OWL H88K")" != "" ]]; then
         MYDTB_FDTFILE="rk3588-hinlink-h88k.dtb"
     fi
     SOC="ak88/h88k"
+elif [[ -f "/etc/flippy-openwrt-release" ]]; then
+    source /etc/flippy-openwrt-release 2>/dev/null
+    if [ -n "${CURRENT_FDTFILE}" ]; then
+        MYDTB_FDTFILE="${CURRENT_FDTFILE}"
+    else
+        MYDTB_FDTFILE="${FDTFILE}"
+    fi
+    SOC="${SOC}"
 else
     echo "Unknown device: [ ${MYDEVICE_NAME} ], Not supported."
     exit 1
 fi
+
+[[ -z "${MYDTB_FDTFILE}" || -z "${SOC}" ]] && {
+    echo "Invalid FDTFILE or SOC: [ ${MYDTB_FDTFILE} / ${SOC} ]"
+    exit 1
+}
+
 echo -e "Current device: ${MYDEVICE_NAME} [ ${SOC} ]"
 sleep 3
 


### PR DESCRIPTION
Support for obtaining `dtb` and `soc` names from the standard `/boot/armbianEnv.txt` and `/etc/flippy-openwrt-release` files further extends support for more custom `rockchip/allwinner` devices.