### PR TITLE
Optimize custom backup list file

### DIFF
--- a/files/openwrt-backup
+++ b/files/openwrt-backup
@@ -14,7 +14,9 @@ BACKUP_FILE="${BACKUP_DIR}/${BACKUP_NAME}"
 # Customize backup list
 backup_list_conf="/etc/amlogic_backup_list.conf"
 if [[ -s "${backup_list_conf}" ]]; then
-    BACKUP_LIST="$(cat ${backup_list_conf} 2>/dev/null)"
+    while IFS= read -r line; do
+        BACKUP_LIST+="${line} "
+    done < "${backup_list_conf}"
 else
     BACKUP_LIST='./etc/AdGuardHome.yaml \
 ./etc/amlogic_backup_list.conf \


### PR DESCRIPTION
Optimized the format of custom backup files, removing the previous requirement for each line to end with a `\`, making it easier for online editing. The format of custom files is as follows:

优化自定义备份文件的格式，移除了原来要求每行以`\`结尾的格式，这样更容易在线编辑。自定义文件的格式如：

```
./etc/AdGuardHome.yaml
./etc/amlogic_backup_list.conf
./etc/balance_irq
./etc/bluetooth/
./etc/config/
./etc/crontabs/
```