### PR TITLE
Support for the latest official partition of OpenWrt

### DIFF
--- a/files/openwrt-backup
+++ b/files/openwrt-backup
@@ -16,7 +16,7 @@ backup_list_conf="/etc/amlogic_backup_list.conf"
 if [[ -s "${backup_list_conf}" ]]; then
     while IFS= read -r line; do
         BACKUP_LIST+="${line} "
-    done < "${backup_list_conf}"
+    done <"${backup_list_conf}"
 else
     BACKUP_LIST='./etc/AdGuardHome.yaml \
 ./etc/amlogic_backup_list.conf \
@@ -118,9 +118,12 @@ backup() {
 restore() {
     # Find the partition where root is located
     ROOT_PTNAME=$(df / | tail -n1 | awk '{print $1}' | awk -F '/' '{print $3}')
-    if [ "${ROOT_PTNAME}" == "" ]; then
-        echo "Cannot find the partition corresponding to the root file system!"
-        exit 1
+    if [[ -z "${ROOT_PTNAME}" ]]; then
+        ROOT_PTNAME="$(df /overlay | tail -n1 | awk '{print $1}' | awk -F '/' '{print $3}')"
+        if [[ -z "${ROOT_PTNAME}" ]]; then
+            echo "Cannot find the partition corresponding to the root file system!"
+            exit 1
+        fi
     fi
 
     # Find the disk where the partition is located, only supports mmcblk?p? sd?? hd?? vd?? and other formats
@@ -164,9 +167,12 @@ restore() {
 gen_fstab() {
     # Find the partition where root is located
     ROOT_PTNAME=$(df / | tail -n1 | awk '{print $1}' | awk -F '/' '{print $3}')
-    if [ "${ROOT_PTNAME}" == "" ]; then
-        echo "Cannot find the partition corresponding to the root file system!"
-        exit 1
+    if [[ -z "${ROOT_PTNAME}" ]]; then
+        ROOT_PTNAME="$(df /overlay | tail -n1 | awk '{print $1}' | awk -F '/' '{print $3}')"
+        if [[ -z "${ROOT_PTNAME}" ]]; then
+            echo "Cannot find the partition corresponding to the root file system!"
+            exit 1
+        fi
     fi
 
     # Find the disk where the partition is located, only supports mmcblk?p? sd?? hd?? vd?? and other formats
@@ -186,9 +192,12 @@ gen_fstab() {
     esac
 
     ROOT_MSG=$(lsblk -l -o NAME,PATH,MOUNTPOINT,UUID,FSTYPE,LABEL | awk '$3 ~ /^\/$/ {print $0}')
-    if [ "$ROOT_MSG" == "" ]; then
-        echo "Get rootfs message failed!"
-        exit 1
+    if [[ -z "${ROOT_MSG}" ]]; then
+        ROOT_MSG=$(lsblk -l -o NAME,PATH,MOUNTPOINT,UUID,FSTYPE,LABEL | awk '$3 ~ /^\/overlay$/ {print $0}')
+        if [[ -z "${ROOT_MSG}" ]]; then
+            echo "Get rootfs message failed!"
+            exit 1
+        fi
     fi
 
     ROOT_NAME=$(echo $ROOT_MSG | awk '{print $1}')
@@ -380,10 +389,13 @@ delete_snapshot() {
 
 migrate_snapshot() {
     cur_rootdev=$(lsblk -l -o NAME,MOUNTPOINT | awk '$2~/^\/$/ {print $1}')
-    if [ "${cur_rootdev}" == "" ]; then
-        echo "The disk device corresponding to the current rootfs cannot be found!"
-        read -p "Press [ enter ] to return." q
-        return
+    if [[ -z "${cur_rootdev}" ]]; then
+        cur_rootdev=$(lsblk -l -o NAME,MOUNTPOINT | awk '$2~/^\/overlay$/ {print $1}')
+        if [[ -z "${cur_rootdev}" ]]; then
+            echo "The disk device corresponding to the current rootfs cannot be found!"
+            read -p "Press [ enter ] to return." q
+            return
+        fi
     fi
     dev_pre=$(echo "${cur_rootdev}" | awk '{print substr($1, 1, length($1)-1);}')
     rootdev_idx=$(echo "${cur_rootdev}" | awk '{print substr($1, length($1),1);}')

--- a/files/openwrt-ddbr
+++ b/files/openwrt-ddbr
@@ -53,6 +53,9 @@ do_checkemmc() {
 
 	# Find the partition where root is located
 	root_ptname="$(df / | tail -n1 | awk '{print $1}' | awk -F '/' '{print $3}')"
+	if [[ -z "${root_ptname}" ]]; then
+		root_ptname="$(df /overlay | tail -n1 | awk '{print $1}' | awk -F '/' '{print $3}')"
+	fi
 	[[ -z "${root_ptname}" ]] && error_msg "Cannot find the partition corresponding to the root file system!"
 
 	# Find the EMMC drive
@@ -136,7 +139,7 @@ do_checkemmc
 echo -ne "${OPT} Do you want to backup or restore? Backup=(b) Restore=(r): "
 read br
 case "${br}" in
-	b | B | backup)  do_backup ;;
-	r | R | restore) do_restore ;;
-	*)               exit 0 ;;
+b | B | backup) do_backup ;;
+r | R | restore) do_restore ;;
+*) exit 0 ;;
 esac

--- a/files/openwrt-install-amlogic
+++ b/files/openwrt-install-amlogic
@@ -65,6 +65,9 @@ fi
 
 # Find the device name of /
 root_devname=$(df / | tail -n1 | awk '{print $1}' | awk -F '\/' '{print substr($3, 1, length($3)-2)}')
+if [[ -z "${root_devname}" ]]; then
+    root_devname="$(df /overlay | tail -n1 | awk '{print $1}' | awk -F '\/' '{print substr($3, 1, length($3)-2)}')"
+fi
 if lsblk -l | grep -E "^${root_devname}boot0" >/dev/null; then
     echo "you are running in emmc mode, please boot system with usb or tf card!"
     exit 1

--- a/files/openwrt-kernel
+++ b/files/openwrt-kernel
@@ -83,6 +83,9 @@ init_var() {
 
     # Find the partition where root is located
     ROOT_PTNAME="$(df / | tail -n1 | awk '{print $1}' | awk -F '/' '{print $3}')"
+    if [[ -z "${ROOT_PTNAME}" ]]; then
+        ROOT_PTNAME="$(df /overlay | tail -n1 | awk '{print $1}' | awk -F '/' '{print $3}')"
+    fi
     [[ -n "${ROOT_PTNAME}" ]] || error_msg "Cannot find the partition corresponding to the root file system!"
 
     # Find the disk where the partition is located, only supports mmcblk?p? sd?? hd?? vd?? and other formats

--- a/files/openwrt-update-allwinner
+++ b/files/openwrt-update-allwinner
@@ -50,9 +50,12 @@ fi
 
 # Find the partition where root is located
 ROOT_PTNAME=$(df / | tail -n1 | awk '{print $1}' | awk -F '/' '{print $3}')
-if [ "${ROOT_PTNAME}" == "" ]; then
-    echo "Cannot find the partition corresponding to the root file system!"
-    exit 1
+if [[ -z "${ROOT_PTNAME}" ]]; then
+    ROOT_PTNAME="$(df /overlay | tail -n1 | awk '{print $1}' | awk -F '/' '{print $3}')"
+    if [[ -z "${ROOT_PTNAME}" ]]; then
+        echo "Cannot find the partition corresponding to the root file system!"
+        exit 1
+    fi
 fi
 
 # Find the disk where the partition is located, only supports mmcblk?p? sd?? hd?? vd?? and other formats
@@ -142,16 +145,19 @@ n* | N*)
     ;;
 esac
 
-BOOT_NAME=$(echo $BOOT_PART_MSG | awk '{print $1}')
-BOOT_PATH=$(echo $BOOT_PART_MSG | awk '{print $2}')
-BOOT_UUID=$(echo $BOOT_PART_MSG | awk '{print $4}')
+BOOT_NAME=$(echo ${BOOT_PART_MSG} | awk '{print $1}')
+BOOT_PATH=$(echo ${BOOT_PART_MSG} | awk '{print $2}')
+BOOT_UUID=$(echo ${BOOT_PART_MSG} | awk '{print $4}')
 
 # find root partition
 ROOT_PART_MSG=$(lsblk -l -o NAME,PATH,TYPE,UUID,MOUNTPOINT | awk '$3~/^part$/ && $5 ~ /^\/$/ {print $0}')
-ROOT_NAME=$(echo $ROOT_PART_MSG | awk '{print $1}')
-ROOT_PATH=$(echo $ROOT_PART_MSG | awk '{print $2}')
-ROOT_UUID=$(echo $ROOT_PART_MSG | awk '{print $4}')
-case $ROOT_NAME in
+if [[ -z "${ROOT_PART_MSG}" ]]; then
+    ROOT_PART_MSG=$(lsblk -l -o NAME,PATH,TYPE,UUID,MOUNTPOINT | awk '$3~/^part$/ && $5 ~ /^\/overlay$/ {print $0}')
+fi
+ROOT_NAME=$(echo ${ROOT_PART_MSG} | awk '{print $1}')
+ROOT_PATH=$(echo ${ROOT_PART_MSG} | awk '{print $2}')
+ROOT_UUID=$(echo ${ROOT_PART_MSG} | awk '{print $4}')
+case ${ROOT_NAME} in
 ${EMMC_NAME}${PARTITION_NAME}2)
     NEW_ROOT_NAME="${EMMC_NAME}${PARTITION_NAME}3"
     NEW_ROOT_LABEL="${LB_PRE}ROOTFS2"

--- a/files/openwrt-update-amlogic
+++ b/files/openwrt-update-amlogic
@@ -33,9 +33,12 @@ fi
 
 # Find the partition where root is located
 ROOT_PTNAME=$(df / | tail -n1 | awk '{print $1}' | awk -F '/' '{print $3}')
-if [ "${ROOT_PTNAME}" == "" ]; then
-    echo "Cannot find the partition corresponding to the root file system!"
-    exit 1
+if [[ -z "${ROOT_PTNAME}" ]]; then
+    ROOT_PTNAME="$(df /overlay | tail -n1 | awk '{print $1}' | awk -F '/' '{print $3}')"
+    if [[ -z "${ROOT_PTNAME}" ]]; then
+        echo "Cannot find the partition corresponding to the root file system!"
+        exit 1
+    fi
 fi
 
 # Find the disk where the partition is located, only supports mmcblk?p? sd?? hd?? vd?? and other formats
@@ -151,11 +154,14 @@ esac
 
 # find root partition
 ROOT_PART_MSG=$(lsblk -l -o NAME,PATH,TYPE,UUID,MOUNTPOINT | awk '$3~/^part$/ && $5 ~ /^\/$/ {print $0}')
+if [[ -z "${ROOT_PART_MSG}" ]]; then
+    ROOT_PART_MSG=$(lsblk -l -o NAME,PATH,TYPE,UUID,MOUNTPOINT | awk '$3~/^part$/ && $5 ~ /^\/overlay$/ {print $0}')
+fi
 ROOT_NAME=$(echo ${ROOT_PART_MSG} | awk '{print $1}')
 ROOT_PATH=$(echo ${ROOT_PART_MSG} | awk '{print $2}')
 ROOT_UUID=$(echo ${ROOT_PART_MSG} | awk '{print $4}')
 
-case $ROOT_NAME in
+case ${ROOT_NAME} in
 ${EMMC_NAME}${PARTITION_NAME}2)
     NEW_ROOT_NAME="${EMMC_NAME}${PARTITION_NAME}3"
     NEW_ROOT_LABEL="${LB_PRE}ROOTFS2"

--- a/files/openwrt-update-kvm
+++ b/files/openwrt-update-kvm
@@ -49,9 +49,12 @@ fi
 # Find the partition where root is located
 # vda2 or vda3
 ROOT_PTNAME=$(df / | tail -n1 | awk '{print $1}' | awk -F '/' '{print $3}')
-if [ "${ROOT_PTNAME}" == "" ]; then
-    echo "Cannot find the partition corresponding to the root file system!"
-    exit 1
+if [[ -z "${ROOT_PTNAME}" ]]; then
+    ROOT_PTNAME="$(df /overlay | tail -n1 | awk '{print $1}' | awk -F '/' '{print $3}')"
+    if [[ -z "${ROOT_PTNAME}" ]]; then
+        echo "Cannot find the partition corresponding to the root file system!"
+        exit 1
+    fi
 fi
 
 # Find the disk where the partition is located, only supports sd?? hd?? vd??
@@ -166,11 +169,14 @@ fi
 
 # find root partition
 ROOT_PART_MSG=$(lsblk -l -o NAME,PATH,TYPE,UUID,MOUNTPOINT | awk '$3~/^part$/ && $5 ~ /^\/$/ {print $0}')
-ROOT_NAME=$(echo $ROOT_PART_MSG | awk '{print $1}')
-ROOT_DEV=$(echo $ROOT_PART_MSG | awk '{print $2}')
-ROOT_UUID=$(echo $ROOT_PART_MSG | awk '{print $4}')
+if [[ -z "${ROOT_PART_MSG}" ]]; then
+    ROOT_PART_MSG=$(lsblk -l -o NAME,PATH,TYPE,UUID,MOUNTPOINT | awk '$3~/^part$/ && $5 ~ /^\/overlay$/ {print $0}')
+fi
+ROOT_NAME=$(echo ${ROOT_PART_MSG} | awk '{print $1}')
+ROOT_DEV=$(echo ${ROOT_PART_MSG} | awk '{print $2}')
+ROOT_UUID=$(echo ${ROOT_PART_MSG} | awk '{print $4}')
 
-case $ROOT_NAME in
+case ${ROOT_NAME} in
 ${DISK_NAME}${PART_PRESTR}2)
     NEW_ROOT_NAME="${DISK_NAME}${PART_PRESTR}3"
     NEW_ROOT_LABEL="${LABEL_PRESTR}ROOTFS2"

--- a/files/openwrt-update-rockchip
+++ b/files/openwrt-update-rockchip
@@ -216,9 +216,12 @@ sleep 3
 
 # Find the partition where root is located
 ROOT_PTNAME=$(df / | tail -n1 | awk '{print $1}' | awk -F '/' '{print $3}')
-if [ "${ROOT_PTNAME}" == "" ]; then
-    echo "Cannot find the partition corresponding to the root file system!"
-    exit 1
+if [[ -z "${ROOT_PTNAME}" ]]; then
+    ROOT_PTNAME="$(df /overlay | tail -n1 | awk '{print $1}' | awk -F '/' '{print $3}')"
+    if [[ -z "${ROOT_PTNAME}" ]]; then
+        echo "Cannot find the partition corresponding to the root file system!"
+        exit 1
+    fi
 fi
 
 # Find the disk where the partition is located, only supports mmcblk?p? sd?? hd?? vd?? and other formats
@@ -319,6 +322,9 @@ BOOT_UUID=$(echo ${BOOT_PART_MSG} | awk '{print $4}')
 
 # find root partition
 ROOT_PART_MSG=$(lsblk -l -o NAME,PATH,TYPE,UUID,MOUNTPOINT | awk '$3~/^part$/ && $5 ~ /^\/$/ {print $0}')
+if [[ -z "${ROOT_PART_MSG}" ]]; then
+    ROOT_PART_MSG=$(lsblk -l -o NAME,PATH,TYPE,UUID,MOUNTPOINT | awk '$3~/^part$/ && $5 ~ /^\/overlay$/ {print $0}')
+fi
 ROOT_NAME=$(echo ${ROOT_PART_MSG} | awk '{print $1}')
 ROOT_PATH=$(echo ${ROOT_PART_MSG} | awk '{print $2}')
 ROOT_UUID=$(echo ${ROOT_PART_MSG} | awk '{print $4}')


### PR DESCRIPTION
官方源编译的tar包的分区情况：

![Snip20240130_2](https://github.com/unifreq/openwrt_packit/assets/68696949/e0440813-4747-4424-a605-8f157c19f2b4)

[openwrt](https://github.com/openwrt/openwrt) 适配了下官方源的分区，对 [lede](https://github.com/coolsnowwolf/lede) 无影响。