### PR TITLE
Adjust the workspace to support simulated physical disk

### DIFF
--- a/openwrt_flippy.sh
+++ b/openwrt_flippy.sh
@@ -107,7 +107,7 @@ DISTRIB_DESCRIPTION_VALUE="OpenWrt"
 STEPS="[\033[95m STEPS \033[0m]"
 INFO="[\033[94m INFO \033[0m]"
 SUCCESS="[\033[92m SUCCESS \033[0m]"
-PROMPT="[\033[93m PROMPT \033[0m]"
+NOTE="[\033[93m NOTE \033[0m]"
 WARNING="[\033[93m WARNING \033[0m]"
 ERROR="[\033[91m ERROR \033[0m]"
 #
@@ -123,7 +123,7 @@ init_var() {
 
     # Install the compressed package
     sudo apt-get -qq update
-    sudo apt-get -qq install -y curl wget subversion git coreutils p7zip p7zip-full zip unzip gzip xz-utils pigz zstd jq tar
+    sudo apt-get -qq install -y curl git coreutils p7zip p7zip-full zip unzip gzip xz-utils pigz zstd jq tar
 
     # Specify the default value
     [[ -n "${SCRIPT_REPO_URL}" ]] || SCRIPT_REPO_URL="${SCRIPT_REPO_URL_VALUE}"
@@ -200,6 +200,7 @@ init_var() {
         KERNEL_TAGS=()
         KERNEL_TAGS=($(echo "${KERNEL_TAGS_TMP[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
     }
+    echo -e "${INFO} Package directory: [ /opt/${SELECT_PACKITPATH} ]"
     echo -e "${INFO} Package SoC: [ $(echo ${PACKAGE_OPENWRT[@]} | xargs) ]"
     echo -e "${INFO} Kernel tags: [ $(echo ${KERNEL_TAGS[@]} | xargs) ]"
 
@@ -222,9 +223,11 @@ init_var() {
 init_packit_repo() {
     cd /opt
 
-    # clone ${SELECT_PACKITPATH} repo
-    echo -e "${STEPS} Start cloning repository [ ${SCRIPT_REPO_URL} ], branch [ ${SCRIPT_REPO_BRANCH} ] into [ ${SELECT_PACKITPATH} ]"
-    git clone -q --single-branch --depth=1 --branch=${SCRIPT_REPO_BRANCH} ${SCRIPT_REPO_URL} ${SELECT_PACKITPATH}
+    # Clone the repository into the packaging directory
+    [[ -d "${SELECT_PACKITPATH}" ]] || {
+        echo -e "${STEPS} Start cloning repository [ ${SCRIPT_REPO_URL} ], branch [ ${SCRIPT_REPO_BRANCH} ] into [ ${SELECT_PACKITPATH} ]"
+        git clone -q --single-branch --depth=1 --branch=${SCRIPT_REPO_BRANCH} ${SCRIPT_REPO_URL} ${SELECT_PACKITPATH}
+    }
 
     # Check the *rootfs.tar.gz package
     [[ -z "${OPENWRT_ARMVIRT}" ]] && error_msg "The [ OPENWRT_ARMVIRT ] variable must be specified."
@@ -232,8 +235,8 @@ init_packit_repo() {
     # Load *-armvirt-64-default-rootfs.tar.gz
     rm -f ${SELECT_PACKITPATH}/${PACKAGE_FILE}
     if [[ "${OPENWRT_ARMVIRT}" == http* ]]; then
-        echo -e "${STEPS} wget [ ${OPENWRT_ARMVIRT} ] file into [ ${SELECT_PACKITPATH} ]"
-        wget ${OPENWRT_ARMVIRT} -q -O ${SELECT_PACKITPATH}/${PACKAGE_FILE}
+        echo -e "${STEPS} curl [ ${OPENWRT_ARMVIRT} ] file into [ ${SELECT_PACKITPATH} ]"
+        curl -fsSL "${OPENWRT_ARMVIRT}" -o "${SELECT_PACKITPATH}/${PACKAGE_FILE}"
         [[ "${?}" -eq "0" ]] || error_msg "Openwrt rootfs file download failed."
     else
         echo -e "${STEPS} copy [ ${GITHUB_WORKSPACE}/${OPENWRT_ARMVIRT} ] file into [ ${SELECT_PACKITPATH} ]"
@@ -254,8 +257,8 @@ init_packit_repo() {
     [[ -n "${SCRIPT_DIY_PATH}" ]] && {
         rm -f ${SELECT_PACKITPATH}/${SCRIPT_DIY}
         if [[ "${SCRIPT_DIY_PATH}" == http* ]]; then
-            echo -e "${INFO} Use wget to download custom script file: [ ${SCRIPT_DIY_PATH} ]"
-            wget ${SCRIPT_DIY_PATH} -q -O ${SELECT_PACKITPATH}/${SCRIPT_DIY}
+            echo -e "${INFO} Use curl to download custom script file: [ ${SCRIPT_DIY_PATH} ]"
+            curl -fsSL "${SCRIPT_DIY_PATH}" -o "${SELECT_PACKITPATH}/${SCRIPT_DIY}"
             [[ "${?}" -eq "0" ]] || error_msg "Custom script file download failed."
         else
             echo -e "${INFO} Copy custom script file: [ ${SCRIPT_DIY_PATH} ]"
@@ -374,7 +377,7 @@ download_kernel() {
                     kernel_down_from="https://github.com/${KERNEL_REPO_URL}/releases/download/kernel_${vb}/${kernel_var}.tar.gz"
                     echo -e "${INFO} (${x}.${i}) [ ${vb} - ${kernel_var} ] Kernel download from [ ${kernel_down_from} ]"
 
-                    wget "${kernel_down_from}" -q -P "${kernel_path}"
+                    curl -fsSL "${kernel_down_from}" -o "${kernel_path}/${kernel_var}.tar.gz"
                     [[ "${?}" -ne "0" ]] && error_msg "Failed to download the kernel files from the server."
 
                     tar -mxf "${kernel_path}/${kernel_var}.tar.gz" -C "${kernel_path}"
@@ -421,13 +424,13 @@ make_openwrt() {
                 {
                     # Rockchip rk3568 series only support 6.x.y and above kernel
                     [[ -n "$(echo "${PACKAGE_OPENWRT_KERNEL6[@]}" | grep -w "${PACKAGE_VAR}")" && "${kernel_var:0:1}" -ne "6" ]] && {
-                        echo -e "${STEPS} (${i}.${k}) ${PROMPT} ${PACKAGE_VAR} cannot use ${kernel_var} kernel, skip."
+                        echo -e "${STEPS} (${i}.${k}) ${NOTE} ${PACKAGE_VAR} cannot use ${kernel_var} kernel, skip."
                         let k++
                         continue
                     }
 
                     # Check the available size of server space
-                    now_remaining_space="$(df -Tk ${PWD} | grep '/dev/' | awk '{print $5}' | echo $(($(xargs) / 1024 / 1024)))"
+                    now_remaining_space="$(df -Tk /opt/${SELECT_PACKITPATH} | grep '/dev/' | awk '{print $5}' | echo $(($(xargs) / 1024 / 1024)))"
                     [[ "${now_remaining_space}" -le "3" ]] && {
                         echo -e "${WARNING} If the remaining space is less than 3G, exit this packaging. \n"
                         break
@@ -516,11 +519,11 @@ EOF
                     echo -e "${STEPS} (${i}.${k}) Start making compressed files in the [ ${SELECT_OUTPUTPATH} ] directory."
                     cd /opt/${SELECT_PACKITPATH}/${SELECT_OUTPUTPATH}
                     case "${GZIP_IMGS}" in
-                        7z | .7z)      ls *.img | head -n 1 | xargs -I % sh -c '7z a -t7z -r %.7z %; rm -f %' ;;
-                        zip | .zip)    ls *.img | head -n 1 | xargs -I % sh -c 'zip %.zip %; rm -f %' ;;
-                        zst | .zst)    zstd --rm *.img ;;
-                        xz | .xz)      xz -z *.img ;;
-                        gz | .gz | *)  pigz -f *.img ;;
+                        7z | .7z)      ls *.img | head -n 1 | xargs -I % sh -c 'sudo 7z a -t7z -r %.7z %; rm -f %' ;;
+                        zip | .zip)    ls *.img | head -n 1 | xargs -I % sh -c 'sudo zip %.zip %; rm -f %' ;;
+                        zst | .zst)    sudo zstd --rm *.img ;;
+                        xz | .xz)      sudo xz -z *.img ;;
+                        gz | .gz | *)  sudo pigz -f *.img ;;
                     esac
 
                     echo -e "${SUCCESS} (${i}.${k}) OpenWrt packaging succeeded: [ ${PACKAGE_VAR} - ${vb} - ${kernel_var} ] \n"
@@ -545,11 +548,12 @@ out_github_env() {
 
         if [[ "${SAVE_OPENWRT_ARMVIRT}" == "true" ]]; then
             echo -e "${INFO} copy [ ${PACKAGE_FILE} ] into [ ${SELECT_OUTPUTPATH} ]"
-            cp -f ../${PACKAGE_FILE} .
+            sudo cp -f ../${PACKAGE_FILE} .
         fi
 
         # Generate a sha256sum verification file for each OpenWrt file
-        for file in *; do [[ ! -d "${file}" ]] && sha256sum "${file}" >"${file}.sha"; done
+        for file in *; do [[ ! -d "${file}" ]] && sudo sha256sum "${file}" | sudo tee "${file}.sha" > /dev/null; done
+        sudo rm -f *.sha.sha 2>/dev/null
 
         echo "PACKAGED_OUTPUTPATH=${PWD}" >>${GITHUB_ENV}
         echo "PACKAGED_OUTPUTDATE=$(date +"%m.%d.%H%M")" >>${GITHUB_ENV}
@@ -564,20 +568,23 @@ out_github_env() {
         echo "PACKAGED_STATUS=failure" >>${GITHUB_ENV}
     fi
 }
-
 # Show welcome message
 echo -e "${STEPS} Welcome to use the OpenWrt packaging tool! \n"
 echo -e "${INFO} Server CPU configuration information: \n$(cat /proc/cpuinfo | grep name | cut -f2 -d: | uniq -c) \n"
-echo -e "${INFO} Server space usage before starting to compile:\n$(df -hT ${PWD}) \n"
 
-# Packit OpenWrt
+# Start initializing variables
 init_var
 init_packit_repo
+
+# Show server start information
+echo -e "${INFO} Server space usage before starting to compile:\n$(df -hT /opt/${SELECT_PACKITPATH}) \n"
+
+# Packit OpenWrt
 [[ "${KERNEL_AUTO_LATEST}" == "true" ]] && query_kernel
 download_kernel
 make_openwrt
 out_github_env
 
 # Show server end information
-echo -e "${INFO} Server space usage after compilation:\n$(df -hT ${PWD}) \n"
+echo -e "${INFO} Server space usage after compilation:\n$(df -hT /opt/${SELECT_PACKITPATH}) \n"
 echo -e "${SUCCESS} The packaging process has been completed. \n"


### PR DESCRIPTION
Create a logical volume using a method that utilizes `110G` of Github Actions space, refer to:

https://github.com/ophub/flippy-openwrt-actions/blob/30e984352f5f05a8cb0a457c617add4b5d2f94d1/.github/workflows/packaging-openwrt.yml#L134