### PR TITLE
Add support for OneCloudPro-V1.1_V1.2(s912)

### DIFF
--- a/files/amlogic_model_database.txt
+++ b/files/amlogic_model_database.txt
@@ -21,7 +21,7 @@
 1k:CM211-1:s905l3:meson-gxl-s905l3b-m302a.dtb:u-boot-p212.bin:NA:NA:2+8G,100Mb-Nic
 
 # Amlogic GXM Family
-21:Octopus Planet:s912:meson-gxm-octopus-planet.dtb:u-boot-zyxq.bin:NA:NA:4C@1512Mhz+4C@1000Mhz,2GB Mem,1Gb Nic
+21:Octopus-Planet/OneCloudPro-V1.1:s912:meson-gxm-octopus-planet.dtb:u-boot-zyxq.bin:NA:NA:4C@1512Mhz+4C@1000Mhz,2GB Mem,1Gb Nic
 22:*FAKE* Octopus Planet *FAKE*:s912:meson-gxm-fake-octopus-planet.dtb:u-boot-zyxq.bin:NA:/lib/u-boot/bl-fake-octopus-planet.bin:4C@1512Mhz+4C@1000Mhz,2GB Mem,1Gb Nic
 23:TX9-Pro(3G_32G_1Gb):s912:meson-gxm-tx9-pro.dtb:u-boot-zyxq.bin:NA:NA:4C@1512Mhz+4C@1000Mhz,2GB Mem,1Gb Nic,brcm43455 wifi
 24:H96 Pro Plus:s912:meson-gxm-octopus-planet.dtb:u-boot-zyxq.bin:NA:NA:2G/32G,1Gb Nic
@@ -34,6 +34,7 @@
 2b:Tanix TX8 MAX:s912:meson-gxm-tx8-max.dtb:u-boot-p212.bin:NA:NA:3GB RAM,16GB/32GB eMMC,2.4G/5.0G WiFi,qca9377 WLAN/Bluetooth 4.1,1Gb Nic
 2c:Vontar-X92:s912:meson-gxm-x92.dtb:u-boot-p212.bin:NA:NA:3GB RAM,16GB/32GB eMMC,2.4G/5.0G WiFi,AP6255 WLAN/Bluetooth 4.0,1Gb Nic:meson-gxm:s912:no
 2d:Phicomm-T1:s912:meson-gxm-phicomm-t1.dtb:u-boot-s905x-s912.bin:NA:NA:2G RAM,16G ROM,100Mb Nic,Wifi,Bluetooth
+2e:OneCloudPro-V1.2:s912:meson-gxm-octopus-planet.dtb:u-boot-zyxq.bin:NA:NA:4C@1512Mhz+4C@1000Mhz,2GB Mem,1Gb Nic
 
 # Amlogic G12A Family
 31:X96 Max 4GB:s905x2:meson-g12a-x96-max.dtb:u-boot-x96max.bin:/lib/u-boot/x96max-u-boot.bin.sd.bin:NA:4C@1908Mhz,4GB Mem,1Gb Nic

--- a/files/openwrt-install-amlogic
+++ b/files/openwrt-install-amlogic
@@ -264,7 +264,13 @@ done
 # you can change ROOT size(MB) >= 320
 ROOT1="960"
 ROOT2="960"
-if [[ "${AMLOGIC_SOC}" == "s912" || "${AMLOGIC_SOC}" == "s905d" ]]; then
+if [[ "${AMLOGIC_SOC}" == "s912" ]] && [[ "${boxtype}" == "213" || "${boxtype}" == "2e" ]]; then
+    BOOT="512"
+    BLANK1="700"
+    BLANK2="220"
+    BLANK3="0"
+    BLANK4="0"
+elif [[ "${AMLOGIC_SOC}" == "s912" || "${AMLOGIC_SOC}" == "s905d" ]]; then
     BOOT="512"
     BLANK1="68"
     BLANK2="220"


### PR DESCRIPTION
根据贡献者 @longjuanfeng05 的反馈（ https://github.com/ophub/amlogic-s9xxx-armbian/pull/2241 ），玩客云OneCloudPro-V1.1（蓝色）可以使用和章鱼星球相同的配置，分区写入位置一致。玩客云OneCloudPro-V1.2（黑色）分区方法不同，需要独立设置一个id，在安装脚本里设置不同的跳过位置。